### PR TITLE
Prepend rather than append entries

### DIFF
--- a/chrome/content/scripts/zoterocitationcounts.js
+++ b/chrome/content/scripts/zoterocitationcounts.js
@@ -53,7 +53,7 @@ function setCitationCount(item, tag, count) {
     const yyyy = today.getFullYear();
     const date = yyyy + '-' + mm + '-' + dd
     // extras.push("Citations (" + tag + "): " + count + " [" + date + "]");
-    extras.push("" + count + " citations (" + tag + ") [" + date + "]");
+    extras.unshift("" + count + " citations (" + tag + ") [" + date + "]");
     extra = extras.join("\n");
     item.setField('extra', extra);
 }


### PR DESCRIPTION
Hi, 

This PR attempts to prepend rather than append the citation info so that it is easier to sort the items by citation count with the Extra column. It should remove the need to use other javascripts/SQL to clean the Extra field.