### PR TITLE
Prepend rather than append items

### DIFF
--- a/chrome/content/scripts/zoterocitationcounts.js
+++ b/chrome/content/scripts/zoterocitationcounts.js
@@ -53,7 +53,7 @@ function setCitationCount(item, tag, count) {
     const yyyy = today.getFullYear();
     const date = yyyy + '-' + mm + '-' + dd
     // extras.push("Citations (" + tag + "): " + count + " [" + date + "]");
-    extras.push("" + count + " citations (" + tag + ") [" + date + "]");
+    extras.unshift("" + count + " citations (" + tag + ") [" + date + "]");
     extra = extras.join("\n");
     item.setField('extra', extra);
 }


### PR DESCRIPTION
This PR attemps to prepend rather than append the citation count to the Extra field. Should make it easier to sort the items in Zotero by citations.