### PR TITLE
extract DOI from extra field is doi field is empty

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version='1.3.0'
+version='1.3.1'
 
 rm -f zotero-citationcounts-${version}.xpi
 zip -r zotero-citationcounts-${version}.xpi chrome/* defaults/* chrome.manifest install.rdf

--- a/install.rdf
+++ b/install.rdf
@@ -7,7 +7,7 @@
         RDF:about="urn:mozilla:install-manifest"
         em:id="schnetter@gmail.com"
         em:name="Zotero Citation Counts Manager"
-        em:version="1.3.0"
+        em:version="1.3.1"
         em:type="2"
         em:creator="Erik Schnetter"
         em:description="Automatically fetch and update citation counts"

--- a/update.rdf
+++ b/update.rdf
@@ -1,17 +1,17 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:em="http://www.mozilla.org/2004/em-rdf#">
   <rdf:Description rdf:about="urn:mozilla:extension:schnetter@gmail.com">
     <em:updates>
       <rdf:Seq>
         <rdf:li>
           <rdf:Description>
-            <em:version>1.3.0</em:version>
+            <em:version>1.3.1</em:version>
             <em:targetApplication>
               <rdf:Description>
                 <em:id>zotero@chnm.gmu.edu</em:id>
                 <em:minVersion>6.0</em:minVersion>
                 <em:maxVersion>6.*</em:maxVersion>
-                <em:updateLink>https://github.com/eschnett/zotero-citationcounts/releases/download/v1.3.0/zotero-citationcounts-1.3.0.xpi</em:updateLink>
+                <em:updateLink>https://github.com/eschnett/zotero-citationcounts/releases/download/v1.3.1/zotero-citationcounts-1.3.1.xpi</em:updateLink>
               </rdf:Description>
             </em:targetApplication>
           </rdf:Description>


### PR DESCRIPTION
Solves #20 and also integrates #29. And instantly versions bumps the project.
Tested this with on +-200 books with DOI in extra field, and regex seems to cover the normally exported format.

Edit:
If you checkout this branch and run `bin/build.sh` file, it should give you an xpi file which you can import in zotero as version 1.3.1